### PR TITLE
Assert that asterisks in Scaladoc comments are properly indented

### DIFF
--- a/lint
+++ b/lint
@@ -81,7 +81,8 @@ class ScalaLinter(object):
           asterisk_index = line.find("*")
           expected_indentation = scaladoc_indentation + 1
           if (asterisk_index != expected_indentation):
-            msg = "Expected * at offset {0} but found it at offset {1}".format(expected_indentation, asterisk_index)
+            msg = "Expected * at offset {0} but found it at offset {1}".format(
+              expected_indentation, asterisk_index)
             error(filepath, lineno, line, asterisk_index, msg)
           if line.find("*/") != -1:
             inside_scaladoc = False

--- a/lint
+++ b/lint
@@ -70,11 +70,26 @@ class ScalaLinter(object):
   def check(self, filepath):
     with open(filepath, "r") as f:
       lineno = 0
+      inside_scaladoc = False
+      scaladoc_indentation = -1
       for line in f:
         Linter.check_line_length(filepath, lineno, line[:-1])
         Linter.disallow_char(filepath, lineno, line, "\t", "\\t")
-        lineno += 1
 
+        # Check Scaladoc indentation
+        if (inside_scaladoc):
+          asterisk_index = line.find("*")
+          expected_indentation = scaladoc_indentation + 1
+          if (asterisk_index != expected_indentation):
+            msg = "Expected * at offset {0} but found it at offset {1}".format(expected_indentation, asterisk_index)
+            error(filepath, lineno, line, asterisk_index, msg)
+          if line.find("*/") != -1:
+            inside_scaladoc = False
+        else:
+          scaladoc_indentation = line.find("/**")
+          if scaladoc_indentation != -1:
+            inside_scaladoc = True
+        lineno += 1
 
 linters = [
   PyLinter(),


### PR DESCRIPTION
Test:

``` scala
/** This
 *  should
 *  be
 *  fine!
 */

 /** This
  *  is
   *  not
  *  fine!
  */

  /** This
  *  is
   *  not
  *  fine!
  */
```

Output:

```
[jess@localhost dev-tools]$ ./lint -p Foo.scala 
/home/jess/projects/dev-tools/Foo.scala:8: Expected * at offset 2 but found it at offset 3
   *  not

   ^
/home/jess/projects/dev-tools/Foo.scala:13: Expected * at offset 3 but found it at offset 2
  *  is

  ^
/home/jess/projects/dev-tools/Foo.scala:15: Expected * at offset 3 but found it at offset 2
  *  fine!

  ^
/home/jess/projects/dev-tools/Foo.scala:16: Expected * at offset 3 but found it at offset 2
  */
  ^
4 lint errors found.
```
